### PR TITLE
Remove duplicate id-token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,6 @@ permissions:
   contents: write
   id-token: write
   packages: write
-  id-token: write
 
 jobs:
   container:


### PR DESCRIPTION
Removes a duplicated id-token that was preventing GitHub actions from
running the release process.

It's fine if you want to toss this PR and not accept external contributions. I
just saw the issue and figured it would be an easy fix. I'm eager to do some dry
run testing of this webhook on my side and am hoping this change may allow me to
start testing with nightly builds of what you're working on.
