### PR TITLE
fix: remove docker.io from image repo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,7 +48,6 @@ dockers:
     dockerfile: .goreleaser.Dockerfile
     image_templates:
       - ghcr.io/rackerlabs/{{ .ProjectName }}:{{ .Version }}-amd64
-      - docker.io/rackerlabs/{{ .ProjectName }}:{{ .Version }}-amd64
     build_flag_templates:
       - --platform=linux/arm64
       - --label=org.opencontainers.image.version={{ .Version }}
@@ -67,7 +66,6 @@ dockers:
     dockerfile: .goreleaser.Dockerfile
     image_templates:
       - ghcr.io/rackerlabs/{{ .ProjectName }}:{{ .Version }}-arm64
-      - docker.io/rackerlabs/{{ .ProjectName }}:{{ .Version }}-arm64
     build_flag_templates:
       - --platform=linux/arm64
       - --label=org.opencontainers.image.version={{ .Version }}


### PR DESCRIPTION
This PR removes the docker.io from the artifact repo