### PR TITLE
chore: update default tags to follow the chart metadata

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,8 +72,7 @@ jobs:
           PKG_VER=${GITHUB_REF_NAME#v}
 
           # update Chart.yaml with tag version
-          yq -i ".appVersion = \"${PKG_VER}\" | .version = \"${PKG_VER}\"" charts/Chart.yaml
-          yq -i ".rackspaceWebhook.image.tag = \"${PKG_VER}\"" charts/values.yaml
+          yq -i ".version = \"${PKG_VER}\"" charts/Chart.yaml
 
           # package chart
           helm package -u -d ${{ github.workspace }} charts

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       - name: external-dns
         securityContext:
           {{- toYaml .Values.externalDns.containerSecurityContext | nindent 10 }}
-        image: "{{ .Values.externalDns.image.repository }}:{{ .Values.externalDns.image.tag }}"
+        image: "{{ .Values.externalDns.image.repository }}:{{ .Values.externalDns.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.externalDns.image.pullPolicy }}
         args:
           - --domain-filter={{ .Values.domainFilter }}
@@ -47,7 +47,7 @@ spec:
       - name: rackspace-webhook
         securityContext:
           {{- toYaml .Values.rackspaceWebhook.containerSecurityContext | nindent 10 }}
-        image: "{{ .Values.rackspaceWebhook.image.repository }}:{{ .Values.rackspaceWebhook.image.tag }}"
+        image: "{{ .Values.rackspaceWebhook.image.repository }}:{{ .Values.rackspaceWebhook.image.tag | default (printf "v%s" .Chart.Version) }}"
         imagePullPolicy: {{ .Values.rackspaceWebhook.image.pullPolicy }}
         ports:
         - name: http

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -8,7 +8,8 @@ externalDns:
   enabled: true
   image:
     repository: registry.k8s.io/external-dns/external-dns
-    tag: v0.18.0
+    # -- defaults to the Chart's AppVersion which should match the External DNS release
+    tag: ""
     pullPolicy: IfNotPresent
   replicas: 1
   serviceAccount:
@@ -63,7 +64,8 @@ rackspaceWebhook:
   enabled: true
   image:
     repository: ghcr.io/rackerlabs/external-dns-rackspace-webhook
-    tag: latest
+    # -- defaults to the Chart version which matches the container version
+    tag: ""
     pullPolicy: IfNotPresent 
   secret:
     create: true


### PR DESCRIPTION
Use the Chart version to pick the tag of the webhook container and use the AppVersion to pick the version of External DNS.