### PR TITLE
Containers in the pod should not have overlapping port names

### DIFF
--- a/examples/deploy.yaml
+++ b/examples/deploy.yaml
@@ -164,14 +164,14 @@ spec:
         image: ghcr.io/rackerlabs/external-dns-rackspace-webhook:latest
         imagePullPolicy: IfNotPresent
         ports:
-        - name: http
+        - name: http-webhook
           protocol: TCP
           containerPort: 8888
         livenessProbe:
           failureThreshold: 2
           httpGet:
             path: /healthz
-            port: http
+            port: http-webhook
           initialDelaySeconds: 10
           periodSeconds: 10
           successThreshold: 1
@@ -180,7 +180,7 @@ spec:
           failureThreshold: 6
           httpGet:
             path: /healthz
-            port: http
+            port: http-webhook
           initialDelaySeconds: 5
           periodSeconds: 10
           successThreshold: 1


### PR DESCRIPTION
This solves the following warning:
Warning: spec.template.spec.containers[1].ports[0]: duplicate port name "http" with spec.template.spec.containers[0].ports[0], services and probes that select ports by name will use spec.template.spec.containers[0].ports[0]