### PR TITLE
fix: auto delete issue when sync and txt flags are present.

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -3,7 +3,7 @@ name: external-dns-rackspace
 description: A Helm chart for deploying external-dns with Rackspace webhook provider
 type: application
 version: 0.2.0
-appVersion: "v0.18.0"
+appVersion: "v0.20.0"
 keywords:
   - external-dns
   - dns

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -15,7 +16,7 @@ import (
 )
 
 const (
-	defaultPort             = 8888
+	defaultPort             = 2020
 	defaultIdentityEndpoint = "https://identity.api.rackspacecloud.com/v2.0/"
 )
 
@@ -48,16 +49,16 @@ func getStartPort() (int, error) {
 	}
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		return 0, fmt.Errorf("invalid port %s", err.Error())
+		return 0, fmt.Errorf("invalid port format: %s", portStr)
 	}
 	return port, nil
 }
 
 func loadConfig() *providers.RackspaceConfig {
 	config := &providers.RackspaceConfig{
-		Username:         os.Getenv("RACKSPACE_USERNAME"),
-		APIKey:           os.Getenv("RACKSPACE_API_KEY"),
-		IdentityEndpoint: os.Getenv("RACKSPACE_IDENTITY_ENDPOINT"),
+		Username:         strings.TrimSpace(os.Getenv("RACKSPACE_USERNAME")),
+		APIKey:           strings.TrimSpace(os.Getenv("RACKSPACE_API_KEY")),
+		IdentityEndpoint: strings.TrimSpace(os.Getenv("RACKSPACE_IDENTITY_ENDPOINT")),
 		DryRun:           false,
 		LogLevel:         "info",
 	}
@@ -79,8 +80,14 @@ func loadConfig() *providers.RackspaceConfig {
 	}
 
 	// Validate required fields
-	if config.Username == "" || config.APIKey == "" {
-		log.Fatal("RACKSPACE_USERNAME and RACKSPACE_API_KEY are required")
+	if config.Username == "" {
+		log.Fatal("RACKSPACE_USERNAME is required and cannot be empty")
+	}
+	if config.APIKey == "" {
+		log.Fatal("RACKSPACE_API_KEY is required and cannot be empty")
+	}
+	if _, err := url.Parse(config.IdentityEndpoint); err != nil {
+		log.Fatalf("Invalid RACKSPACE_IDENTITY_ENDPOINT URL: %v", err)
 	}
 
 	return config

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	defaultPort             = 2020
+	defaultPort             = 8888
 	defaultIdentityEndpoint = "https://identity.api.rackspacecloud.com/v2.0/"
 )
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -8,6 +8,7 @@ import (
 )
 
 func ConfigureRoutes(e *echo.Echo, h *handlers.Handler) {
+	e.Use(echoMiddleware.Recover())
 	e.Pre(echoMiddleware.RemoveTrailingSlash())
 	e.Use(middleware.ExternalDNSContentTypeMiddleware)
 


### PR DESCRIPTION
This PR updates
- fix the reported issue #20
- Using latest version of external-dns in helm charts

Correct way to use with txt

```yaml
        - --domain-filter=example.com
        - --interval=10s
        - --log-format=text
        - --log-level=debug
        - --policy=sync
        - --provider=webhook
        - --registry=txt
        - --txt-prefix=external-dns-  # ADD THIS LINE
        - --source=ingress
        - --txt-owner-id=primary
        - --webhook-provider-url=http://192.168.1.16:2020
```

This will create a new TXT entry in Rackspace DNS.

<img width="738" height="80" alt="image" src="https://github.com/user-attachments/assets/16b919d0-539b-4a35-bf0a-da18cae4e708" />
