### PR TITLE
Fix: updates to work with external-dns chart

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -55,9 +55,9 @@ spec:
         image: "{{ .Values.rackspaceWebhook.image.repository }}:{{ .Values.rackspaceWebhook.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.rackspaceWebhook.image.pullPolicy }}
         ports:
-        - name: http
+        - name: http-webhook
           protocol: TCP
-          containerPort: 8888
+          containerPort: 8080
         livenessProbe:
           {{- toYaml .Values.rackspaceWebhook.livenessProbe | nindent 10 }}
         readinessProbe:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -4,7 +4,6 @@ namespace: external-dns
 # -- Domain filter for DNS management (list of domains)
 domainFilter:
   - example.com
-
 # External DNS configuration
 externalDns:
   # -- Enable external-dns deployment
@@ -83,7 +82,6 @@ externalDns:
     timeoutSeconds: 5
   # -- Resource limits and requests for external-dns
   resources: {}
-
 # Rackspace Webhook configuration
 rackspaceWebhook:
   # -- Enable Rackspace webhook deployment
@@ -125,7 +123,7 @@ rackspaceWebhook:
     failureThreshold: 2
     httpGet:
       path: /healthz
-      port: http
+      port: http-webhook
     initialDelaySeconds: 10
     periodSeconds: 10
     successThreshold: 1
@@ -135,7 +133,7 @@ rackspaceWebhook:
     failureThreshold: 6
     httpGet:
       path: /healthz
-      port: http
+      port: http-webhook
     initialDelaySeconds: 5
     periodSeconds: 10
     successThreshold: 1

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -66,10 +66,12 @@ func main() {
 	// Expose healthz/readyz/metrics endpoints publicly
 	go func() { errCh <- ops.Start(fmt.Sprintf(":%d", defaultHealthzPort)) }()
 
+	exitCode := 0
 	select {
 	case err = <-errCh:
 		if !errors.Is(err, http.ErrServerClosed) {
 			log.Printf("server error: %v", err)
+			exitCode = 1
 		}
 	case <-ctx.Done():
 		log.Println("shutdown signal received")
@@ -86,6 +88,7 @@ func main() {
 	if err := ops.Shutdown(shutdownCtx); err != nil {
 		log.Printf("ops shutdown error: %v", err)
 	}
+	os.Exit(exitCode)
 }
 
 func getStartPort() (int, error) {

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/labstack/echo/v4"
 
@@ -16,7 +22,12 @@ import (
 )
 
 const (
-	defaultPort             = 8888
+	//This is the internal port external-dns talks to the webhook on must always
+	//scoped to localhost:<PORT> but the port is configurable via the external-dns chart
+	defaultPort = 8888
+	//external-dns hardcodes the public healthz/readyz/metrics port in the chart to 8080
+	//this can't change unless the chart changes
+	defaultHealthzPort      = 8080
 	defaultIdentityEndpoint = "https://identity.api.rackspacecloud.com/v2.0/"
 )
 
@@ -28,17 +39,52 @@ func main() {
 		log.Fatalf("Failed to create Rackspace provider: %v", err)
 	}
 	handler := handlers.NewHandler(provider)
-	e := echo.New()
-	e.HideBanner = true
-	routes.ConfigureRoutes(e, handler)
 
 	port, err := getStartPort()
 	if err != nil {
 		log.Fatalf("invalid port %s", err)
 	}
 
-	if err = e.Start(fmt.Sprintf(":%d", port)); err != nil {
-		log.Fatalf("failed to start server: %v", err)
+	// Webhook API server — localhost only
+	webhook := echo.New()
+	webhook.HideBanner = true
+	routes.ConfigureWebhookRoutes(webhook, handler)
+
+	// Ops server — all interfaces
+	ops := echo.New()
+	ops.HideBanner = true
+	routes.ConfigureOpsRoutes(ops, handler)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 2)
+
+	// Always scope to localhost:<port>
+	go func() { errCh <- webhook.Start(fmt.Sprintf("localhost:%d", port)) }()
+
+	// Expose healthz/readyz/metrics endpoints publicly
+	go func() { errCh <- ops.Start(fmt.Sprintf(":%d", defaultHealthzPort)) }()
+
+	select {
+	case err = <-errCh:
+		if !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("server error: %v", err)
+		}
+	case <-ctx.Done():
+		log.Println("shutdown signal received")
+	}
+	stop()
+
+	// Allow in-flight requests to drain before K8s sends SIGKILL (default 30s grace).
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	defer cancel()
+
+	if err := webhook.Shutdown(shutdownCtx); err != nil {
+		log.Printf("webhook shutdown error: %v", err)
+	}
+	if err := ops.Shutdown(shutdownCtx); err != nil {
+		log.Printf("ops shutdown error: %v", err)
 	}
 }
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -7,13 +7,12 @@ import (
 	"github.com/rackerlabs/external-dns-rackspace-webhook/internal/middleware"
 )
 
-func ConfigureRoutes(e *echo.Echo, h *handlers.Handler) {
+// ConfigureWebhookRoutes sets up the external-dns webhook API routes (localhost only).
+func ConfigureWebhookRoutes(e *echo.Echo, h *handlers.Handler) {
 	e.Use(echoMiddleware.Recover())
 	e.Pre(echoMiddleware.RemoveTrailingSlash())
 	e.Use(middleware.ExternalDNSContentTypeMiddleware)
 
-	// Health check endpoint
-	e.GET("/healthz", h.HealthHandler)
 	// Domain filter negotiation endpoint
 	e.GET("/", h.NegotiationHandler)
 	// Get all DNS records
@@ -22,4 +21,10 @@ func ConfigureRoutes(e *echo.Echo, h *handlers.Handler) {
 	e.POST("/records", h.HandlePostRecords)
 	// Adjust endpoints (optional preprocessing)
 	e.POST("/adjustendpoints", h.HandleAdjustEndpoints)
+}
+
+// ConfigureOpsRoutes sets up operational endpoints exposed on all interfaces.
+func ConfigureOpsRoutes(e *echo.Echo, h *handlers.Handler) {
+	e.Use(echoMiddleware.Recover())
+	e.GET("/healthz", h.HealthHandler)
 }


### PR DESCRIPTION
The external-dns hardcodes port 8080 as a container port and is the expected port to expose healthz/readyz/metrics endpoints on. The 8080 port should be on all interfaces (:8080) and public based on documentation (https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/webhook-provider/#provider-endpoints). The port that external-dns interacts with the provider on defaults to port 8888 and is only scoped to `localhost:8888` which is updatedable via the chart but is never exposed publicly.