### PR TITLE
fix: resolve DNS record churning caused by Records/AdjustEndpoints

### DIFF
--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/labstack/echo/v4"
@@ -34,9 +33,15 @@ func (h *Handler) HandleGetRecords(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}
 
+	log.Info("GET /records", "count", len(endpoints))
 	return c.JSON(http.StatusOK, endpoints)
 }
 
+// HandleAdjustEndpoints returns endpoints unchanged. Rackspace does not
+// require any provider-specific canonicalization. Transforming endpoints
+// here (adding trailing dots, modifying TTL, stripping TXT quotes) caused
+// mismatches with what Records() returns and with the TXT registry's
+// internal representation, leading to constant update churn.
 func (h *Handler) HandleAdjustEndpoints(c echo.Context) error {
 	defer c.Request().Body.Close()
 	var endpoints []*endpoint.Endpoint
@@ -45,59 +50,8 @@ func (h *Handler) HandleAdjustEndpoints(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 
-	log.Debug("Adjusting endpoints", "count", len(endpoints))
-	adjusted := make([]*endpoint.Endpoint, 0, len(endpoints))
-
-	for _, ep := range endpoints {
-		if ep == nil {
-			log.Warn("Skipping nil endpoint")
-			continue
-		}
-		if ep == nil || ep.DNSName == "" || len(ep.Targets) == 0 {
-			log.Warn("Skipping invalid endpoint", "dnsName", ep.DNSName)
-			continue
-		}
-		// Canonicalize DNS name
-		dnsName := strings.ToLower(strings.TrimSuffix(ep.DNSName, ".")) + "."
-		if !h.provider.DomainFilter.Match(dnsName) {
-			log.Warn("Endpoint outside domain filter", "dnsName", dnsName)
-			continue
-		}
-
-		// Skip unsupported record types
-		if ep.RecordType == "NS" || ep.RecordType == "SOA" {
-			log.Warn("Skipping unsupported record type", "dnsName", dnsName, "recordType", ep.RecordType)
-			continue
-		}
-
-		// Normalize TTL: ensure it’s at least 300, default 300 if not set
-		ttl := ep.RecordTTL
-		if !ttl.IsConfigured() {
-			ttl = endpoint.TTL(300)
-		} else if ttl < 300 {
-			log.Debug("Adjusting TTL to 300s", "dnsName", dnsName, "originalTTL", ttl)
-			ttl = endpoint.TTL(300)
-		}
-
-		// Normalize TXT targets (Rackspace may return them already quoted)
-		targets := make([]string, 0, len(ep.Targets))
-		for _, t := range ep.Targets {
-			if ep.RecordType == "TXT" {
-				t = strings.Trim(t, `"`)
-			}
-			targets = append(targets, t)
-		}
-
-		adjusted = append(adjusted, &endpoint.Endpoint{
-			DNSName:    dnsName,
-			Targets:    targets,
-			RecordType: ep.RecordType,
-			RecordTTL:  ttl,
-			Labels:     ep.Labels,
-		})
-	}
-
-	return c.JSON(http.StatusOK, adjusted)
+	log.Info("POST /adjustendpoints", "count", len(endpoints))
+	return c.JSON(http.StatusOK, endpoints)
 }
 
 func (h *Handler) HandlePostRecords(c echo.Context) error {
@@ -107,6 +61,7 @@ func (h *Handler) HandlePostRecords(c echo.Context) error {
 		log.Error("Failed to decode input", "error", err)
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
+	log.Info("POST /records", "create", len(changes.Create), "updateNew", len(changes.UpdateNew), "delete", len(changes.Delete))
 	if err := h.provider.ApplyChanges(c.Request().Context(), &changes); err != nil {
 		log.Error("Failed to apply changes", "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/internal/providers/consistency_test.go
+++ b/internal/providers/consistency_test.go
@@ -1,0 +1,375 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rackerlabs/goclouddns/records"
+	"sigs.k8s.io/external-dns/endpoint"
+	"sigs.k8s.io/external-dns/plan"
+
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+)
+
+func TestConvertRecordToEndpoint_TrailingDot(t *testing.T) {
+	tests := []struct {
+		name    string
+		record  records.RecordList
+		wantDNS string
+	}{
+		{
+			name:    "A record without trailing dot",
+			record:  records.RecordList{Name: "myhost.example.com", Type: "A", Data: "10.0.0.1", TTL: 300},
+			wantDNS: "myhost.example.com.",
+		},
+		{
+			name:    "TXT record without trailing dot",
+			record:  records.RecordList{Name: "a-myhost.example.com", Type: "TXT", Data: "heritage=external-dns", TTL: 300},
+			wantDNS: "a-myhost.example.com.",
+		},
+		{
+			name:    "already has trailing dot",
+			record:  records.RecordList{Name: "myhost.example.com.", Type: "A", Data: "10.0.0.1", TTL: 300},
+			wantDNS: "myhost.example.com.",
+		},
+		{
+			name:    "SRV record without trailing dot",
+			record:  records.RecordList{Name: "_mongodb._tcp.myrs.example.com", Type: "SRV", Data: "0 27017 node1.example.com", TTL: 300, Priority: 10},
+			wantDNS: "_mongodb._tcp.myrs.example.com.",
+		},
+		{
+			name:    "CNAME record without trailing dot",
+			record:  records.RecordList{Name: "alias.example.com", Type: "CNAME", Data: "target.example.com", TTL: 300},
+			wantDNS: "alias.example.com.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := convertRecordToEndpoint(tt.record, "example.com")
+			if ep == nil {
+				t.Fatal("convertRecordToEndpoint returned nil")
+			}
+			if ep.DNSName != tt.wantDNS {
+				t.Errorf("DNSName = %q, want %q", ep.DNSName, tt.wantDNS)
+			}
+		})
+	}
+}
+
+func TestConvertRecordToEndpoint_SRVFormat(t *testing.T) {
+	tests := []struct {
+		name       string
+		record     records.RecordList
+		wantTarget string
+	}{
+		{
+			name: "priority prepended to 3-part data",
+			record: records.RecordList{
+				Name: "_mongodb._tcp.myrs.example.com", Type: "SRV",
+				Data: "0 27017 node1.example.com", TTL: 300, Priority: 10,
+			},
+			wantTarget: "10 0 27017 node1.example.com",
+		},
+		{
+			name: "zero priority",
+			record: records.RecordList{
+				Name: "_sip._tcp.svc.example.com", Type: "SRV",
+				Data: "5 5060 sip.example.com", TTL: 300, Priority: 0,
+			},
+			wantTarget: "0 5 5060 sip.example.com",
+		},
+		{
+			name: "high priority value",
+			record: records.RecordList{
+				Name: "_http._tcp.web.example.com", Type: "SRV",
+				Data: "1 443 web.example.com", TTL: 300, Priority: 100,
+			},
+			wantTarget: "100 1 443 web.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := convertRecordToEndpoint(tt.record, "example.com")
+			if ep == nil {
+				t.Fatal("convertRecordToEndpoint returned nil")
+			}
+			if ep.Targets[0] != tt.wantTarget {
+				t.Errorf("SRV target = %q, want %q", ep.Targets[0], tt.wantTarget)
+			}
+		})
+	}
+}
+
+func TestConvertRecordToEndpoint_SkipsNSAndSOA(t *testing.T) {
+	tests := []struct {
+		name       string
+		recordType string
+	}{
+		{name: "NS record", recordType: "NS"},
+		{name: "SOA record", recordType: "SOA"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := records.RecordList{Name: "example.com", Type: tt.recordType, Data: "ns1.example.com", TTL: 300}
+			ep := convertRecordToEndpoint(rec, "example.com")
+			if ep != nil {
+				t.Errorf("expected nil for %s record, got %+v", tt.recordType, ep)
+			}
+		})
+	}
+}
+
+func TestConvertRecordToEndpoint_TXTLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		comment    string
+		wantLabels map[string]string
+	}{
+		{
+			name:       "valid JSON labels in comment",
+			comment:    `{"external-dns/owner":"test-owner"}`,
+			wantLabels: map[string]string{"external-dns/owner": "test-owner"},
+		},
+		{
+			name:       "empty comment",
+			comment:    "",
+			wantLabels: nil,
+		},
+		{
+			name:       "invalid JSON comment",
+			comment:    "not-json",
+			wantLabels: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := records.RecordList{Name: "txt.example.com", Type: "TXT", Data: "v=spf1", TTL: 300, Comment: tt.comment}
+			ep := convertRecordToEndpoint(rec, "example.com")
+			if ep == nil {
+				t.Fatal("convertRecordToEndpoint returned nil")
+			}
+			if tt.wantLabels == nil && ep.Labels != nil {
+				t.Errorf("expected nil labels, got %v", ep.Labels)
+			}
+			for k, v := range tt.wantLabels {
+				if ep.Labels[k] != v {
+					t.Errorf("label %q = %q, want %q", k, ep.Labels[k], v)
+				}
+			}
+		})
+	}
+}
+
+// TestRecordsAdjustEndpointsIdempotent verifies the core invariant: passing
+// Records() output through AdjustEndpoints logic must produce identical results.
+// A mismatch here means external-dns sees "changes" every sync → churning.
+func TestRecordsAdjustEndpointsIdempotent(t *testing.T) {
+	tests := []struct {
+		name          string
+		apiRecords    string // JSON records array from Rackspace
+		wantEndpoints int
+	}{
+		{
+			name: "A and TXT records",
+			apiRecords: `[
+				{"id":"r1","name":"myhost.example.com","type":"A","data":"10.0.0.1","ttl":300},
+				{"id":"r2","name":"a-myhost.example.com","type":"TXT","data":"heritage=external-dns,external-dns/owner=test","ttl":300}
+			]`,
+			wantEndpoints: 2,
+		},
+		{
+			name: "SRV record with separate priority",
+			apiRecords: `[
+				{"id":"r3","name":"_mongodb._tcp.myrs.example.com","type":"SRV","data":"0 27017 node1.example.com","ttl":300,"priority":10}
+			]`,
+			wantEndpoints: 1,
+		},
+		{
+			name: "mixed record types",
+			apiRecords: `[
+				{"id":"r1","name":"myhost.example.com","type":"A","data":"10.0.0.1","ttl":300},
+				{"id":"r2","name":"a-myhost.example.com","type":"TXT","data":"heritage=external-dns","ttl":300},
+				{"id":"r3","name":"_mongodb._tcp.myrs.example.com","type":"SRV","data":"0 27017 node1.example.com","ttl":300,"priority":10},
+				{"id":"r4","name":"alias.example.com","type":"CNAME","data":"target.example.com","ttl":600}
+			]`,
+			wantEndpoints: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			th.SetupHTTP()
+			defer th.TeardownHTTP()
+
+			th.Mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, `{"domains":[{"id":"111","name":"example.com"}]}`)
+			})
+			th.Mux.HandleFunc("/domains/111/records", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"records":%s}`, tt.apiRecords)
+			})
+
+			p := newTestProvider(t)
+			eps, err := p.Records(context.Background())
+			if err != nil {
+				t.Fatalf("Records() error: %v", err)
+			}
+			if len(eps) != tt.wantEndpoints {
+				t.Fatalf("Records() returned %d endpoints, want %d", len(eps), tt.wantEndpoints)
+			}
+
+			adjusted := simulateAdjustEndpoints(eps, p.DomainFilter)
+			if len(adjusted) != len(eps) {
+				t.Fatalf("AdjustEndpoints returned %d, Records returned %d", len(adjusted), len(eps))
+			}
+
+			for i := range eps {
+				if eps[i].DNSName != adjusted[i].DNSName {
+					t.Errorf("[%d] DNSName mismatch: Records=%q Adjusted=%q", i, eps[i].DNSName, adjusted[i].DNSName)
+				}
+				for j := range eps[i].Targets {
+					if eps[i].Targets[j] != adjusted[i].Targets[j] {
+						t.Errorf("[%d] Target[%d] mismatch: Records=%q Adjusted=%q", i, j, eps[i].Targets[j], adjusted[i].Targets[j])
+					}
+				}
+				if eps[i].RecordTTL != adjusted[i].RecordTTL {
+					t.Errorf("[%d] TTL mismatch: Records=%d Adjusted=%d", i, eps[i].RecordTTL, adjusted[i].RecordTTL)
+				}
+			}
+		})
+	}
+}
+
+func TestRecords_FiltersNSAndSOA(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"domains":[{"id":"111","name":"example.com"}]}`)
+	})
+	th.Mux.HandleFunc("/domains/111/records", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"records":[
+			{"id":"r1","name":"example.com","type":"NS","data":"ns1.example.com","ttl":3600},
+			{"id":"r2","name":"example.com","type":"SOA","data":"ns1.example.com admin.example.com","ttl":3600},
+			{"id":"r3","name":"myhost.example.com","type":"A","data":"10.0.0.1","ttl":300}
+		]}`)
+	})
+
+	p := newTestProvider(t)
+	eps, err := p.Records(context.Background())
+	if err != nil {
+		t.Fatalf("Records() error: %v", err)
+	}
+	if len(eps) != 1 {
+		t.Fatalf("expected 1 endpoint (NS/SOA filtered), got %d", len(eps))
+	}
+	if eps[0].RecordType != "A" {
+		t.Errorf("expected A record, got %s", eps[0].RecordType)
+	}
+}
+
+func TestRecords_SkipsNonMatchingDomains(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"domains":[
+			{"id":"111","name":"example.com"},
+			{"id":"222","name":"other.com"}
+		]}`)
+	})
+	th.Mux.HandleFunc("/domains/111/records", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"records":[{"id":"r1","name":"myhost.example.com","type":"A","data":"10.0.0.1","ttl":300}]}`)
+	})
+
+	p := newTestProvider(t)
+	eps, err := p.Records(context.Background())
+	if err != nil {
+		t.Fatalf("Records() error: %v", err)
+	}
+	if len(eps) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(eps))
+	}
+}
+
+func TestApplyChanges_DryRun(t *testing.T) {
+	p := &RackspaceProvider{
+		DryRun:       true,
+		DomainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
+	}
+	changes := &plan.Changes{
+		Create: []*endpoint.Endpoint{
+			{DNSName: "new.example.com.", RecordType: "A", Targets: []string{"10.0.0.1"}, RecordTTL: 300},
+		},
+	}
+	if err := p.ApplyChanges(context.Background(), changes); err != nil {
+		t.Errorf("ApplyChanges with DryRun should not error, got: %v", err)
+	}
+}
+
+// simulateAdjustEndpoints replicates HandleAdjustEndpoints logic for test assertions.
+func simulateAdjustEndpoints(endpoints []*endpoint.Endpoint, df *endpoint.DomainFilter) []*endpoint.Endpoint {
+	var out []*endpoint.Endpoint
+	for _, ep := range endpoints {
+		if ep == nil || ep.DNSName == "" || len(ep.Targets) == 0 {
+			continue
+		}
+		dnsName := strings.ToLower(strings.TrimSuffix(ep.DNSName, ".")) + "."
+		if !df.Match(dnsName) {
+			continue
+		}
+		if ep.RecordType == "NS" || ep.RecordType == "SOA" {
+			continue
+		}
+		ttl := ep.RecordTTL
+		if !ttl.IsConfigured() {
+			ttl = endpoint.TTL(300)
+		} else if ttl < 300 {
+			ttl = endpoint.TTL(300)
+		}
+		targets := make([]string, 0, len(ep.Targets))
+		for _, t := range ep.Targets {
+			if ep.RecordType == "TXT" {
+				t = strings.Trim(t, `"`)
+			}
+			targets = append(targets, t)
+		}
+		out = append(out, &endpoint.Endpoint{
+			DNSName:    dnsName,
+			Targets:    targets,
+			RecordType: ep.RecordType,
+			RecordTTL:  ttl,
+			Labels:     ep.Labels,
+		})
+	}
+	return out
+}
+
+func newTestProvider(t *testing.T) *RackspaceProvider {
+	t.Helper()
+	return &RackspaceProvider{
+		serviceClient: NewRackspaceDNSClient(FakeDNSClient()),
+		authProvider:  NewRackspaceAuthProvider(),
+		tokenExpiry:   time.Now().Add(24 * time.Hour),
+		config: &RackspaceConfig{
+			IdentityEndpoint: th.Endpoint(),
+			Username:         "test",
+			APIKey:           "test",
+		},
+		DomainFilter: endpoint.NewDomainFilter([]string{"example.com"}),
+		DryRun:       false,
+	}
+}

--- a/internal/providers/consistency_test.go
+++ b/internal/providers/consistency_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -15,36 +14,21 @@ import (
 	th "github.com/gophercloud/gophercloud/v2/testhelper"
 )
 
-func TestConvertRecordToEndpoint_TrailingDot(t *testing.T) {
+func TestConvertRecordToEndpoint_NoTrailingDot(t *testing.T) {
 	tests := []struct {
 		name    string
 		record  records.RecordList
 		wantDNS string
 	}{
 		{
-			name:    "A record without trailing dot",
+			name:    "A record returned as-is",
 			record:  records.RecordList{Name: "myhost.example.com", Type: "A", Data: "10.0.0.1", TTL: 300},
-			wantDNS: "myhost.example.com.",
+			wantDNS: "myhost.example.com",
 		},
 		{
-			name:    "TXT record without trailing dot",
+			name:    "TXT record returned as-is",
 			record:  records.RecordList{Name: "a-myhost.example.com", Type: "TXT", Data: "heritage=external-dns", TTL: 300},
-			wantDNS: "a-myhost.example.com.",
-		},
-		{
-			name:    "already has trailing dot",
-			record:  records.RecordList{Name: "myhost.example.com.", Type: "A", Data: "10.0.0.1", TTL: 300},
-			wantDNS: "myhost.example.com.",
-		},
-		{
-			name:    "SRV record without trailing dot",
-			record:  records.RecordList{Name: "_mongodb._tcp.myrs.example.com", Type: "SRV", Data: "0 27017 node1.example.com", TTL: 300, Priority: 10},
-			wantDNS: "_mongodb._tcp.myrs.example.com.",
-		},
-		{
-			name:    "CNAME record without trailing dot",
-			record:  records.RecordList{Name: "alias.example.com", Type: "CNAME", Data: "target.example.com", TTL: 300},
-			wantDNS: "alias.example.com.",
+			wantDNS: "a-myhost.example.com",
 		},
 	}
 
@@ -106,6 +90,38 @@ func TestConvertRecordToEndpoint_SRVFormat(t *testing.T) {
 	}
 }
 
+func TestConvertRecordToEndpoint_TXTDataUnmodified(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       string
+		wantTarget string
+	}{
+		{
+			name:       "heritage string returned as-is",
+			data:       "heritage=external-dns,external-dns/owner=test",
+			wantTarget: "heritage=external-dns,external-dns/owner=test",
+		},
+		{
+			name:       "SPF record returned as-is",
+			data:       "v=spf1 include:example.com ~all",
+			wantTarget: "v=spf1 include:example.com ~all",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := records.RecordList{Name: "a-myhost.example.com", Type: "TXT", Data: tt.data, TTL: 300}
+			ep := convertRecordToEndpoint(rec, "example.com")
+			if ep == nil {
+				t.Fatal("convertRecordToEndpoint returned nil")
+			}
+			if ep.Targets[0] != tt.wantTarget {
+				t.Errorf("TXT target = %q, want %q", ep.Targets[0], tt.wantTarget)
+			}
+		})
+	}
+}
+
 func TestConvertRecordToEndpoint_SkipsNSAndSOA(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -134,8 +150,8 @@ func TestConvertRecordToEndpoint_TXTLabels(t *testing.T) {
 	}{
 		{
 			name:       "valid JSON labels in comment",
-			comment:    `{"external-dns/owner":"test-owner"}`,
-			wantLabels: map[string]string{"external-dns/owner": "test-owner"},
+			comment:    `{"ownedRecord":"app.example.com."}`,
+			wantLabels: map[string]string{"ownedRecord": "app.example.com."},
 		},
 		{
 			name:       "empty comment",
@@ -168,84 +184,44 @@ func TestConvertRecordToEndpoint_TXTLabels(t *testing.T) {
 	}
 }
 
-// TestRecordsAdjustEndpointsIdempotent verifies the core invariant: passing
-// Records() output through AdjustEndpoints logic must produce identical results.
-// A mismatch here means external-dns sees "changes" every sync → churning.
-func TestRecordsAdjustEndpointsIdempotent(t *testing.T) {
-	tests := []struct {
-		name          string
-		apiRecords    string // JSON records array from Rackspace
-		wantEndpoints int
-	}{
-		{
-			name: "A and TXT records",
-			apiRecords: `[
-				{"id":"r1","name":"myhost.example.com","type":"A","data":"10.0.0.1","ttl":300},
-				{"id":"r2","name":"a-myhost.example.com","type":"TXT","data":"heritage=external-dns,external-dns/owner=test","ttl":300}
-			]`,
-			wantEndpoints: 2,
-		},
-		{
-			name: "SRV record with separate priority",
-			apiRecords: `[
-				{"id":"r3","name":"_mongodb._tcp.myrs.example.com","type":"SRV","data":"0 27017 node1.example.com","ttl":300,"priority":10}
-			]`,
-			wantEndpoints: 1,
-		},
-		{
-			name: "mixed record types",
-			apiRecords: `[
-				{"id":"r1","name":"myhost.example.com","type":"A","data":"10.0.0.1","ttl":300},
-				{"id":"r2","name":"a-myhost.example.com","type":"TXT","data":"heritage=external-dns","ttl":300},
-				{"id":"r3","name":"_mongodb._tcp.myrs.example.com","type":"SRV","data":"0 27017 node1.example.com","ttl":300,"priority":10},
-				{"id":"r4","name":"alias.example.com","type":"CNAME","data":"target.example.com","ttl":600}
-			]`,
-			wantEndpoints: 4,
-		},
+func TestRecords_MergesMultipleTargets(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"domains":[{"id":"111","name":"example.com"}]}`)
+	})
+	th.Mux.HandleFunc("/domains/111/records", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"records":[
+			{"id":"r1","name":"multi.example.com","type":"A","data":"10.0.0.1","ttl":300},
+			{"id":"r2","name":"multi.example.com","type":"A","data":"10.0.0.2","ttl":300},
+			{"id":"r3","name":"multi.example.com","type":"A","data":"10.0.0.3","ttl":300},
+			{"id":"r4","name":"single.example.com","type":"A","data":"10.0.0.4","ttl":300}
+		]}`)
+	})
+
+	p := newTestProvider(t)
+	eps, err := p.Records(context.Background())
+	if err != nil {
+		t.Fatalf("Records() error: %v", err)
+	}
+	if len(eps) != 2 {
+		t.Fatalf("expected 2 merged endpoints, got %d", len(eps))
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			th.SetupHTTP()
-			defer th.TeardownHTTP()
-
-			th.Mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprint(w, `{"domains":[{"id":"111","name":"example.com"}]}`)
-			})
-			th.Mux.HandleFunc("/domains/111/records", func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintf(w, `{"records":%s}`, tt.apiRecords)
-			})
-
-			p := newTestProvider(t)
-			eps, err := p.Records(context.Background())
-			if err != nil {
-				t.Fatalf("Records() error: %v", err)
+	for _, ep := range eps {
+		if ep.DNSName == "multi.example.com" {
+			if len(ep.Targets) != 3 {
+				t.Errorf("expected 3 targets for multi.example.com, got %d: %v", len(ep.Targets), ep.Targets)
 			}
-			if len(eps) != tt.wantEndpoints {
-				t.Fatalf("Records() returned %d endpoints, want %d", len(eps), tt.wantEndpoints)
+		}
+		if ep.DNSName == "single.example.com" {
+			if len(ep.Targets) != 1 {
+				t.Errorf("expected 1 target for single.example.com, got %d", len(ep.Targets))
 			}
-
-			adjusted := simulateAdjustEndpoints(eps, p.DomainFilter)
-			if len(adjusted) != len(eps) {
-				t.Fatalf("AdjustEndpoints returned %d, Records returned %d", len(adjusted), len(eps))
-			}
-
-			for i := range eps {
-				if eps[i].DNSName != adjusted[i].DNSName {
-					t.Errorf("[%d] DNSName mismatch: Records=%q Adjusted=%q", i, eps[i].DNSName, adjusted[i].DNSName)
-				}
-				for j := range eps[i].Targets {
-					if eps[i].Targets[j] != adjusted[i].Targets[j] {
-						t.Errorf("[%d] Target[%d] mismatch: Records=%q Adjusted=%q", i, j, eps[i].Targets[j], adjusted[i].Targets[j])
-					}
-				}
-				if eps[i].RecordTTL != adjusted[i].RecordTTL {
-					t.Errorf("[%d] TTL mismatch: Records=%d Adjusted=%d", i, eps[i].RecordTTL, adjusted[i].RecordTTL)
-				}
-			}
-		})
+		}
 	}
 }
 
@@ -279,32 +255,6 @@ func TestRecords_FiltersNSAndSOA(t *testing.T) {
 	}
 }
 
-func TestRecords_SkipsNonMatchingDomains(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
-
-	th.Mux.HandleFunc("/domains", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"domains":[
-			{"id":"111","name":"example.com"},
-			{"id":"222","name":"other.com"}
-		]}`)
-	})
-	th.Mux.HandleFunc("/domains/111/records", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"records":[{"id":"r1","name":"myhost.example.com","type":"A","data":"10.0.0.1","ttl":300}]}`)
-	})
-
-	p := newTestProvider(t)
-	eps, err := p.Records(context.Background())
-	if err != nil {
-		t.Fatalf("Records() error: %v", err)
-	}
-	if len(eps) != 1 {
-		t.Fatalf("expected 1 endpoint, got %d", len(eps))
-	}
-}
-
 func TestApplyChanges_DryRun(t *testing.T) {
 	p := &RackspaceProvider{
 		DryRun:       true,
@@ -312,50 +262,12 @@ func TestApplyChanges_DryRun(t *testing.T) {
 	}
 	changes := &plan.Changes{
 		Create: []*endpoint.Endpoint{
-			{DNSName: "new.example.com.", RecordType: "A", Targets: []string{"10.0.0.1"}, RecordTTL: 300},
+			{DNSName: "new.example.com", RecordType: "A", Targets: []string{"10.0.0.1"}, RecordTTL: 300},
 		},
 	}
 	if err := p.ApplyChanges(context.Background(), changes); err != nil {
 		t.Errorf("ApplyChanges with DryRun should not error, got: %v", err)
 	}
-}
-
-// simulateAdjustEndpoints replicates HandleAdjustEndpoints logic for test assertions.
-func simulateAdjustEndpoints(endpoints []*endpoint.Endpoint, df *endpoint.DomainFilter) []*endpoint.Endpoint {
-	var out []*endpoint.Endpoint
-	for _, ep := range endpoints {
-		if ep == nil || ep.DNSName == "" || len(ep.Targets) == 0 {
-			continue
-		}
-		dnsName := strings.ToLower(strings.TrimSuffix(ep.DNSName, ".")) + "."
-		if !df.Match(dnsName) {
-			continue
-		}
-		if ep.RecordType == "NS" || ep.RecordType == "SOA" {
-			continue
-		}
-		ttl := ep.RecordTTL
-		if !ttl.IsConfigured() {
-			ttl = endpoint.TTL(300)
-		} else if ttl < 300 {
-			ttl = endpoint.TTL(300)
-		}
-		targets := make([]string, 0, len(ep.Targets))
-		for _, t := range ep.Targets {
-			if ep.RecordType == "TXT" {
-				t = strings.Trim(t, `"`)
-			}
-			targets = append(targets, t)
-		}
-		out = append(out, &endpoint.Endpoint{
-			DNSName:    dnsName,
-			Targets:    targets,
-			RecordType: ep.RecordType,
-			RecordTTL:  ttl,
-			Labels:     ep.Labels,
-		})
-	}
-	return out
 }
 
 func newTestProvider(t *testing.T) *RackspaceProvider {

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -223,10 +223,24 @@ func convertRecordToEndpoint(record records.RecordList, domainName string) *endp
 			log.Warn("Failed to unmarshal TXT record labels", "name", record.Name, "comment", record.Comment, "error", err)
 		}
 	}
+	// Rackspace returns names without a trailing dot, but AdjustEndpoints
+	// canonicalizes all names with one. Without this, external-dns sees a
+	// diff between Records() and AdjustEndpoints() on every sync cycle,
+	// causing constant create/update/delete churn.
+	dnsName := strings.TrimSuffix(strings.ToLower(record.Name), ".") + "."
+
+	data := record.Data
+	// Rackspace stores SRV priority as a separate API field rather than
+	// inline in the data string. Reassemble into the "priority weight port
+	// target" format that external-dns expects.
+	if record.Type == "SRV" {
+		data = fmt.Sprintf("%d %s", record.Priority, record.Data)
+	}
+
 	ep := &endpoint.Endpoint{
-		DNSName:    record.Name,
+		DNSName:    dnsName,
 		RecordType: record.Type,
-		Targets:    []string{record.Data},
+		Targets:    []string{data},
 		RecordTTL:  endpoint.TTL(record.TTL),
 		Labels:     labels,
 	}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -129,7 +129,9 @@ func authenticateAndCreateClient(ctx context.Context, authProvider AuthProvider,
 }
 
 func (p *RackspaceProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
-	var endpoints []*endpoint.Endpoint
+	// Rackspace stores one target per record. external-dns expects one
+	// endpoint per name+type with all targets merged.
+	merged := map[string]*endpoint.Endpoint{}
 	opts := domains.ListOpts{}
 	pager := p.getClient(ctx).ListDomains(ctx, opts)
 	start := time.Now()
@@ -151,7 +153,12 @@ func (p *RackspaceProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 				}
 				for _, record := range recordList {
 					if ep := convertRecordToEndpoint(record, domain.Name); ep != nil {
-						endpoints = append(endpoints, ep)
+						key := ep.DNSName + "/" + ep.RecordType
+						if existing, ok := merged[key]; ok {
+							existing.Targets = append(existing.Targets, ep.Targets...)
+						} else {
+							merged[key] = ep
+						}
 					}
 				}
 				return true, nil
@@ -162,6 +169,11 @@ func (p *RackspaceProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, 
 		}
 		return true, nil
 	})
+
+	endpoints := make([]*endpoint.Endpoint, 0, len(merged))
+	for _, ep := range merged {
+		endpoints = append(endpoints, ep)
+	}
 	log.Debug("Fetched records", "count", len(endpoints), "elapsed", time.Since(start))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch domains: %w", err)
@@ -217,17 +229,14 @@ func convertRecordToEndpoint(record records.RecordList, domainName string) *endp
 	if record.Type == "NS" || record.Type == "SOA" {
 		return nil
 	}
+	// Comments may contain JSON labels (from external-dns) or plain text
+	// (from other tools). Only attempt to parse if it looks like JSON.
 	var labels map[string]string
-	if record.Type == "TXT" && record.Comment != "" {
+	if record.Type == "TXT" && record.Comment != "" && record.Comment[0] == '{' {
 		if err := json.Unmarshal([]byte(record.Comment), &labels); err != nil {
 			log.Warn("Failed to unmarshal TXT record labels", "name", record.Name, "comment", record.Comment, "error", err)
 		}
 	}
-	// Rackspace returns names without a trailing dot, but AdjustEndpoints
-	// canonicalizes all names with one. Without this, external-dns sees a
-	// diff between Records() and AdjustEndpoints() on every sync cycle,
-	// causing constant create/update/delete churn.
-	dnsName := strings.TrimSuffix(strings.ToLower(record.Name), ".") + "."
 
 	data := record.Data
 	// Rackspace stores SRV priority as a separate API field rather than
@@ -237,14 +246,13 @@ func convertRecordToEndpoint(record records.RecordList, domainName string) *endp
 		data = fmt.Sprintf("%d %s", record.Priority, record.Data)
 	}
 
-	ep := &endpoint.Endpoint{
-		DNSName:    dnsName,
+	return &endpoint.Endpoint{
+		DNSName:    record.Name,
 		RecordType: record.Type,
 		Targets:    []string{data},
 		RecordTTL:  endpoint.TTL(record.TTL),
 		Labels:     labels,
 	}
-	return ep
 }
 
 func (p *RackspaceProvider) createRecord(ctx context.Context, ep *endpoint.Endpoint) error {


### PR DESCRIPTION
AdjustEndpoints was adding trailing dots to DNS names, normalizing TTL
from 0 to 300, and stripping quotes from TXT targets. These
transformations created mismatches between what Records() returned and
what external-dns expected, causing every record to be updated on every
sync cycle. Per the external-dns webhook contract, AdjustEndpoints
should be a pass-through unless provider-specific canonicalization is
needed.

Additionally, Records() returned one endpoint per Rackspace record, but
external-dns expects one endpoint per name+type with all targets merged.

Changes:
- Make AdjustEndpoints a pass-through (matches BaseProvider default)
- Merge records with same name+type into single multi-target endpoints
- Reassemble SRV priority into the target string (Rackspace stores it
  as a separate API field)
- Skip JSON unmarshal on non-JSON TXT record comments
- Add request logging to all webhook handlers