### PR TITLE
fix: correct SRV record creation and RFC 2782 trailing dot handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ docker build -t external-dns-rackspace-webhook .
 3. **Permission Denied**: Check that your API key has DNS management permissions
 4. **TTL Too Low**: The webhook enforces a minimum TTL of 300 seconds
 
+### external-dns Compatibility (SRV Records)
+
+SRV record support requires external-dns v0.21.0 or later:
+
+- **Versions prior to 0.21** do not include SRV in the TXT registry's `getSupportedTypes()`. This prevents the registry from matching `srv-` prefixed TXT ownership records to their SRV data records, causing all SRV records to appear unowned. external-dns will not update or delete them.
+
+- **Version 0.21.0** fixes the ownership matching but introduces contradictory SRV validation in the CRD source. The CRD validator rejects targets with a trailing dot, while `ValidateSRVRecord` requires one per RFC 2782. This makes it impossible to create SRV records via DNSEndpoint CRDs. See [kubernetes-sigs/external-dns#6357](https://github.com/kubernetes-sigs/external-dns/issues/6357) and the fix in [PR #6383](https://github.com/kubernetes-sigs/external-dns/pull/6383).
+
 ### Debug Mode
 
 Enable debug logging by setting `LOG_LEVEL` in your values file:

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/charmbracelet/log"
 	"github.com/labstack/echo/v4"
@@ -37,17 +38,27 @@ func (h *Handler) HandleGetRecords(c echo.Context) error {
 	return c.JSON(http.StatusOK, endpoints)
 }
 
-// HandleAdjustEndpoints returns endpoints unchanged. Rackspace does not
-// require any provider-specific canonicalization. Transforming endpoints
-// here (adding trailing dots, modifying TTL, stripping TXT quotes) caused
-// mismatches with what Records() returns and with the TXT registry's
-// internal representation, leading to constant update churn.
+// HandleAdjustEndpoints normalises provider-specific endpoint details.
+// For SRV records, RFC 2782 requires the target host to be an absolute
+// FQDN (trailing dot).  Sources that omit the dot would be rejected by
+// external-dns's ValidateSRVRecord, so we append it here as a safety net.
 func (h *Handler) HandleAdjustEndpoints(c echo.Context) error {
 	defer c.Request().Body.Close()
 	var endpoints []*endpoint.Endpoint
 	if err := json.NewDecoder(c.Request().Body).Decode(&endpoints); err != nil {
 		log.Error("Failed to decode input", "error", err)
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	for _, ep := range endpoints {
+		if ep.RecordType == "SRV" {
+			for i, target := range ep.Targets {
+				parts := strings.SplitN(target, " ", 4)
+				if len(parts) == 4 && !strings.HasSuffix(parts[3], ".") {
+					ep.Targets[i] = parts[0] + " " + parts[1] + " " + parts[2] + " " + parts[3] + "."
+				}
+			}
+		}
 	}
 
 	log.Info("POST /adjustendpoints", "count", len(endpoints))

--- a/internal/providers/consistency_test.go
+++ b/internal/providers/consistency_test.go
@@ -57,7 +57,7 @@ func TestConvertRecordToEndpoint_SRVFormat(t *testing.T) {
 				Name: "_mongodb._tcp.myrs.example.com", Type: "SRV",
 				Data: "0 27017 node1.example.com", TTL: 300, Priority: 10,
 			},
-			wantTarget: "10 0 27017 node1.example.com",
+			wantTarget: "10 0 27017 node1.example.com.",
 		},
 		{
 			name: "zero priority",
@@ -65,7 +65,7 @@ func TestConvertRecordToEndpoint_SRVFormat(t *testing.T) {
 				Name: "_sip._tcp.svc.example.com", Type: "SRV",
 				Data: "5 5060 sip.example.com", TTL: 300, Priority: 0,
 			},
-			wantTarget: "0 5 5060 sip.example.com",
+			wantTarget: "0 5 5060 sip.example.com.",
 		},
 		{
 			name: "high priority value",
@@ -73,7 +73,7 @@ func TestConvertRecordToEndpoint_SRVFormat(t *testing.T) {
 				Name: "_http._tcp.web.example.com", Type: "SRV",
 				Data: "1 443 web.example.com", TTL: 300, Priority: 100,
 			},
-			wantTarget: "100 1 443 web.example.com",
+			wantTarget: "100 1 443 web.example.com.",
 		},
 	}
 

--- a/internal/providers/provider_test.go
+++ b/internal/providers/provider_test.go
@@ -2,7 +2,9 @@ package providers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -282,7 +284,7 @@ func TestRackspaceProvider_createRecord(t *testing.T) {
 			endpoint: &endpoint.Endpoint{
 				DNSName:    "_sip._tcp.example.com",
 				RecordType: "SRV",
-				Targets:    []string{"1 5 5060 _sip._tcp.example.com."},
+				Targets:    []string{"1 5 5060 sipserver.example.com"},
 				RecordTTL:  endpoint.TTL(3600),
 				Labels:     map[string]string{},
 			},
@@ -330,6 +332,28 @@ func TestRackspaceProvider_createRecord(t *testing.T) {
 			th.Mux.HandleFunc("/domains/123456/records", func(w http.ResponseWriter, r *http.Request) {
 				th.TestMethod(t, r, "POST")
 				th.TestHeader(t, r, "X-Auth-Token", "cbc36478b0bd8e67e89469c7749d4127")
+
+				if !tt.wantErr {
+					body, _ := io.ReadAll(r.Body)
+					var payload map[string]interface{}
+					if err := json.Unmarshal(body, &payload); err != nil {
+						t.Fatalf("failed to parse request body: %v", err)
+					}
+					recs, _ := payload["records"].([]interface{})
+					if len(recs) > 0 {
+						rec := recs[0].(map[string]interface{})
+						if data, ok := rec["data"].(string); ok {
+							if data != "5 5060 sipserver.example.com" {
+								t.Errorf("SRV data = %q, want %q", data, "5 5060 sipserver.example.com")
+							}
+						}
+						if priority, ok := rec["priority"].(float64); ok {
+							if priority != 1 {
+								t.Errorf("SRV priority = %v, want 1", priority)
+							}
+						}
+					}
+				}
 
 				w.Header().Add("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -244,6 +244,14 @@ func convertRecordToEndpoint(record records.RecordList, domainName string) *endp
 	// target" format that external-dns expects.
 	if record.Type == "SRV" {
 		data = fmt.Sprintf("%d %s", record.Priority, record.Data)
+		// Ensure the target host ends with a dot (RFC 2782) so that the
+		// value returned here matches what adjustEndpoints produces for
+		// the desired endpoints.  Without this trailing dot external-dns
+		// ≥ 0.21 rejects the record as invalid.
+		parts := strings.SplitN(data, " ", 4)
+		if len(parts) == 4 && !strings.HasSuffix(parts[3], ".") {
+			data = parts[0] + " " + parts[1] + " " + parts[2] + " " + parts[3] + "."
+		}
 	}
 
 	return &endpoint.Endpoint{
@@ -288,7 +296,7 @@ func (p *RackspaceProvider) createRecord(ctx context.Context, ep *endpoint.Endpo
 				return err
 			}
 			createOpts.Priority = uint(priority)
-			createOpts.Data = fmt.Sprintf("%s %s %s", parts[1], parts[2], fqdn)
+			createOpts.Data = fmt.Sprintf("%s %s %s", parts[1], parts[2], strings.TrimSuffix(parts[3], "."))
 		}
 
 		if _, err := p.getClient(ctx).CreateRecord(ctx, domain.ID, createOpts); err != nil {


### PR DESCRIPTION
SRV records were created with the record's own DNS name as the target instead of the actual host from the endpoint target string. This caused all SRV records to point at themselves rather than the intended hosts.

Additionally, Rackspace stores SRV target hosts without trailing dots, but external-dns >= 0.21 requires RFC 2782 compliant absolute FQDNs (trailing dot). Add trailing dot normalization in both the read path (convertRecordToEndpoint) and adjustEndpoints so current and desired records match consistently.

external-dns compatibility notes:

- Versions prior to 0.21 (including 0.18 and 0.20) do not include SRV in the TXT registry's getSupportedTypes(), which prevents the registry from matching srv- prefixed TXT ownership records to their SRV data records. This causes all SRV records to appear unowned and external-dns will not update or delete them. Upgrading to >= 0.21 is required.

- CRD-sourced SRV records are broken in external-dns v0.21.0 due to contradictory validation in the CRD source and ValidateSRVRecord. See https://github.com/kubernetes-sigs/external-dns/issues/6357 and the fix in https://github.com/kubernetes-sigs/external-dns/pull/6383. A patched external-dns build is required until that PR is merged.

Changes:
- Use parts[3] instead of fqdn when building SRV data for Rackspace API
- Strip trailing dot before sending to Rackspace (it doesn't use them)
- Append trailing dot to SRV targets returned by Records()
- Append trailing dot to SRV targets in adjustEndpoints as safety net
- Improve SRV test to use distinct target host and validate request body